### PR TITLE
lutris-installers: Hotfix v2025.4-1.1

### DIFF
--- a/installers/lutris-installer-additions.yml
+++ b/installers/lutris-installer-additions.yml
@@ -1,4 +1,4 @@
-## SPT Lutris installer v2025.4-1 ##
+## SPT Lutris installer v2025.4-1.1 ##
 ## This Lutris installer is using an -UNOFFICIAL- bash installer script.
 description: 'Installs SPTarkov for you; EFT needs to be installed manually!'
 notes: "Make sure the main game is installed inside the BSG Launcher before installing SPTarkov.\nCheck out the link for further details & assistance!"
@@ -57,7 +57,7 @@ script:
                      Have fun! ('-')7"
     system:
         env:
-            PROTON_VERB: runinprefix
+            PROTON_VERB: run
             # Possible workarounds for dotnet package issues (SPT Launcher)
             # DOTNET_BUNDLE_EXTRACT_BASE_DIR:
             # DOTNET_ROOT: 

--- a/installers/lutris-installer-official.yml
+++ b/installers/lutris-installer-official.yml
@@ -1,4 +1,4 @@
-## SPT Lutris installer v2025.4-1 ##
+## SPT Lutris installer v2025.4-1.1 ##
 ## This Lutris installer is using the -OFFICIAL- SPT Windows installer.
 description: 'Installs SPTarkov for you; EFT needs to be installed manually!'
 notes: "Make sure the main game is installed inside the BSG Launcher before installing SPTarkov.\nCheck out the link for further details & assistance!"
@@ -55,7 +55,7 @@ script:
                      Have fun! ('-')7"
     system:
         env:
-            PROTON_VERB: runinprefix
+            PROTON_VERB: run
             # Possible workarounds for dotnet package issues (SPT Launcher)
             DOTNET_BUNDLE_EXTRACT_BASE_DIR:
             DOTNET_ROOT: 


### PR DESCRIPTION
- Revert change to envrionment variable `PROTON_VERB` because it breaks loading the Proton runtime correctly bump version