### PR TITLE
Update xxd URL to latest version

### DIFF
--- a/scripts/spt-additions
+++ b/scripts/spt-additions
@@ -90,7 +90,7 @@ URL[umu-run]="https://github.com/Open-Wine-Components/umu-launcher/releases/down
 URL[7zzs]="https://github.com/ip7z/7zip/releases/download/25.01/7z2501-linux-x64.tar.xz"
 URL[hpatchz]="https://github.com/sisong/HDiffPatch/releases/download/v4.11.1/hdiffpatch_v4.11.1_bin_linux64.zip"
 URL[jq]="https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64"
-URL[xxd]="http://ftp.de.debian.org/debian/pool/main/v/vim/xxd_9.1.1846-1_amd64.deb"
+URL[xxd]="http://ftp.de.debian.org/debian/pool/main/v/vim/xxd_9.1.1882-1_amd64.deb"
 URL[ge-proton]="https://github.com/GloriousEggroll/proton-ge-custom/releases"
 
 # Installers


### PR DESCRIPTION
`http://ftp.de.debian.org/debian/pool/main/v/vim/xxd_9.1.1846-1_amd64.deb` now 404's