### PR TITLE
fix: detect EFT via InstallLocation (newer BSG launchers lack UninstallString)

### DIFF
--- a/scripts/spt-additions
+++ b/scripts/spt-additions
@@ -440,14 +440,22 @@ get_eft_path() {
     # get windows path
     [[ ! -f "${WINEPREFIX}/system.reg" ]] && exit 11
     entry=$( sed -n '/Uninstall\\\\EscapeFromTarkov/,/^$/p' "${WINEPREFIX}/system.reg" )
-    path=$( echo "${entry}" | grep -o "\"UninstallString\"=\"[^}]*" | cut -d "\"" -f4 2>/dev/null )
 
-    # Convert to unix path
-    path=$( m_umu winepath -u "${path}" 2>/dev/null )
+    # Newer BSG launchers only store "InstallLocation" (the game directory itself).
+    # Older ones only stored "UninstallString" (an executable inside that directory),
+    # so fall back to it and strip the trailing file name.
+    path=$( echo "${entry}" | grep -o "\"InstallLocation\"=\"[^}]*" | cut -d "\"" -f4 2>/dev/null )
+    if [[ -n "${path}" ]]; then
+        path=$( m_umu winepath -u "${path}" 2>/dev/null )
+    else
+        path=$( echo "${entry}" | grep -o "\"UninstallString\"=\"[^}]*" | cut -d "\"" -f4 2>/dev/null )
+        path=$( m_umu winepath -u "${path}" 2>/dev/null )
+        path="${path%/*}"
+    fi
     [[ -z "${path}" ]] && exit 12
 
-    # Finally assemble the full path & return it
-    printf "%s\n" "${path%/*}"
+    # Finally assemble the full path & return it (strip a possible trailing slash)
+    printf "%s\n" "${path%/}"
 }
 
 


### PR DESCRIPTION
## Problem

`get_eft_path()` fails on current BSG launcher versions, aborting the installer with:

```
[spt-additions] Warn:  Looks like EFT is not installed!
[spt-additions] ERROR opt_guided_install: Failed to get EFT install path (Exit code: 1)
```

…even though Escape from Tarkov **is** installed correctly inside the prefix.

## Root cause

`get_eft_path()` extracts the game directory exclusively from the `"UninstallString"` value of the `…\Uninstall\EscapeFromTarkov` registry key:

```bash
path=$( echo "${entry}" | grep -o "\"UninstallString\"=\"[^}]*" | cut -d "\"" -f4 )
```

Newer BSG launchers (observed: **15.0.0.4559**) no longer write an `UninstallString` for that key. The key now only contains:

```
[Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\EscapeFromTarkov]
"InstallLocation"="C:\Battlestate Games\Escape from Tarkov"
```

So the grep returns an empty string → `winepath` returns empty → `exit 12` → "not installed".

This is the same failure reported in #43.

## Fix

Read `"InstallLocation"` first — it already points at the game directory, so no `dirname` stripping is applied. Fall back to the previous `"UninstallString"` behaviour (strip trailing file name) for older launcher versions, and strip a possible trailing slash.

```bash
path=$( echo "${entry}" | grep -o "\"InstallLocation\"=\"[^}]*" | cut -d "\"" -f4 )
if [[ -n "${path}" ]]; then
    path=$( m_umu winepath -u "${path}" )
else
    path=$( echo "${entry}" | grep -o "\"UninstallString\"=\"[^}]*" | cut -d "\"" -f4 )
    path=$( m_umu winepath -u "${path}" )
    path="${path%/*}"
fi
```

## Testing

- `bash -n scripts/spt-additions` passes.
- Against a real prefix with launcher 15.0.0.4559 the new logic resolves `EFT_DIR` to `…/drive_c/Battlestate Games/Escape from Tarkov`, where `EscapeFromTarkov.exe` exists. The old logic returned an empty path on the same prefix.

Fixes #43