### PR TITLE
spt-additions: Fix live install detection for current BSG Launcher

### DIFF
--- a/scripts/spt-additions
+++ b/scripts/spt-additions
@@ -440,18 +440,24 @@ update_eft_path() {
     [[ ! -f "${CONFIG[WINEPREFIX]}/system.reg" ]] && return 1
     entry=$(sed -n '/Uninstall\\\\EscapeFromTarkov/,/^$/p' "${CONFIG[WINEPREFIX]}/system.reg")
     path=$(echo "${entry}" | grep -o "\"UninstallString\"=\"[^}]*" | cut -d "\"" -f4 2>/dev/null)
-    # Convert to unix path
-    path=$(m_umu winepath -u "${path}" 2>/dev/null)
-    
-    if [[ -z "${path}" ]]; then
+
+    if [[ -n "${path}" ]]; then
+        # Convert to unix path & remove the filename
+        path=$(m_umu winepath -u "${path}" 2>/dev/null)
+        path="${path%/*}"
+    else
+        # Current BSG Launcher only writes "InstallLocation" (already the game dir)
+        path=$(echo "${entry}" | grep -o "\"InstallLocation\"=\"[^}]*" | cut -d "\"" -f4 2>/dev/null)
+        [[ -n "${path}" ]] && path=$(m_umu winepath -u "${path}" 2>/dev/null)
+    fi
+
+    if [[ -z "${path}" || ! -d "${path}" ]]; then
         return 1
     fi
 
-    if [[ -n "${path%/*}" ]]; then
-        msg; msg "${BOLD}Found live install at:${RESET}"
-        msg "   ► ${path%/*}"; msg
-        set_value config "eft-path=${path%/*}"
-    fi
+    msg; msg "${BOLD}Found live install at:${RESET}"
+    msg "   ► ${path}"; msg
+    set_value config "eft-path=${path}"
 }
 
 


### PR DESCRIPTION
## Problem

Guided install (`spt-additions` v1.2.4/v1.2.5) aborts after the game has been fully downloaded & installed via the live launcher:

```
Warn:  Looks like the game is not installed!
   ► Make sure that the game is installed inside the game launcher
   ► & that you can see the "Play" button
ERROR opt_guided_install: Failed to get game install path (Exit code: 1)
```

The game **is** installed at that point (~78 GB in `drive_c/Battlestate Games/Escape from Tarkov`, `EscapeFromTarkov.exe` present, Play button visible in the launcher).

## Root cause

`update_eft_path()` extracts the live install path from the `UninstallString` value of the `Uninstall\EscapeFromTarkov` key in `system.reg`:

```bash
entry=$(sed -n '/Uninstall\\\\EscapeFromTarkov/,/^$/p' "${CONFIG[WINEPREFIX]}/system.reg")
path=$(echo "${entry}" | grep -o "\"UninstallString\"=\"[^}]*" | cut -d "\"" -f4 2>/dev/null)
```

The current BSG Launcher (15.0.0.4595, Inno Setup) only writes `InstallLocation` into that key — there is **no** `UninstallString` anymore:

```
[Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\EscapeFromTarkov] 1787255591
#time=1dd30dd880e5d88
"InstallLocation"="C:\\Battlestate Games\\Escape from Tarkov"
```

So the grep returns nothing, `winepath -u ""` receives an empty path (log signature: `Proton: Error: unable to use parent for game drive, path `), and detection fails even though the game is present.

Same root cause as #43 — that reporter's registry block also contained only `InstallLocation`.

## Fix

In `update_eft_path()`:

- Keep the existing `UninstallString` parsing for older launchers (including the `${path%/*}` filename strip).
- If empty, fall back to `InstallLocation` — unlike `UninstallString` it already points at the game directory, so the filename strip is skipped.
- Verify the resolved directory actually exists (`-d`) before accepting it, so a stale/bogus registry entry can no longer produce an invalid `eft-path`.

## Testing

Tested against a real prefix (BSG Launcher 15.0.0.4595, GE-Proton11-5, umu-launcher 1.4.4, Arch Linux):

| Scenario | Result |
|---|---|
| Key with `UninstallString` (old launcher behavior) | resolves to game dir, filename stripped |
| Key with only `InstallLocation` (current launcher, the bug) | fallback resolves to the same game dir |
| Empty / missing `system.reg` | correctly returns 1 |

`bash -n` syntax check passes. The workaround that unblocks affected users right now (adds the missing value manually) is no longer needed with this patch:

```bash
WINEPREFIX="<prefix>" PROTONPATH="<proton>" umu-run reg add \
  "HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\EscapeFromTarkov" \
  /v UninstallString /t REG_SZ /d "C:\Battlestate Games\Escape from Tarkov\uninstall.exe" /f
```
