### PR TITLE
spt-additions: Update v1.2.6

### DIFF
--- a/scripts/spt-additions
+++ b/scripts/spt-additions
@@ -995,7 +995,6 @@ install_spt() {
 
     # Install dependencies
     install_verb "dotnetdesktop9" ".NET Desktop Runtime 9.0"
-    install_verb "dotnetdesktop10" ".NET Desktop Runtime 10.0"
 
     # Add DLL overrides
     opt_dlloverride winhttp n,b


### PR DESCRIPTION
- Removed `dotnetdesktop10` dependency since it causes issues for some users
- Default to latest Proton in case the configured Proton version is not installed
- Update `hpatchz` dependency to v1.5.3
- Update metadata
- Bump version
